### PR TITLE
add hover state to homepage table rows

### DIFF
--- a/app/controllers/states_controller.rb
+++ b/app/controllers/states_controller.rb
@@ -65,6 +65,7 @@ def doubling_time_from_hash(hash, sec_ago = WEEK_SEC)
   h={} 
   t0 = Time.now.to_i - sec_ago
   hash.to_a.sort.reverse.each {|t,v| h[v] = t if t.to_i > t0 } 
+  return nil if h.size <= 2
   arr=h.to_a.map {|v,t| [t,v]}.sort 
   xs = arr.map {|t,v| t} 
   ys = arr.map {|t,v| v} 

--- a/app/views/states/summary.html.erb
+++ b/app/views/states/summary.html.erb
@@ -25,7 +25,7 @@ This page provides a record of official data from US government websites for the
 <p>
 For updates that include provisional sources, please visit the <a href="https://coronavirusapi.com/?unofficial=y">provisional summary.</a>
 </p>
-<table id="fulltable" class="table table-sm table-bordered table-striped">
+<table id="fulltable" class="table table-sm table-bordered table-striped table-hover">
   <thead>
     <tr>
       <th>State</th>


### PR DESCRIPTION
This PR adds a bootstrap class supporting a hover state for rows in the homepage table. I personally like having as hover state on rows since this table is very wide on desktop. For instance when looking at columns in the middle of the table, it is easy to lose track of which state the data refers to.

Just a thought 😃 

Example: https://getbootstrap.com/docs/4.0/content/tables/#hoverable-rows

In our case:

<img width="445" alt="Screen Shot 2020-04-02 at 11 59 11 AM" src="https://user-images.githubusercontent.com/24446573/78277056-7fdaea80-74d9-11ea-8349-51ec65d1bacb.png">
<img width="321" alt="Screen Shot 2020-04-02 at 11 58 27 AM" src="https://user-images.githubusercontent.com/24446573/78277058-810c1780-74d9-11ea-96df-5337277760fb.png">
